### PR TITLE
feat: enhance blog SEO with OG tags, JSON-LD, and reading time

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -83,3 +83,14 @@ export function getAdjacentPosts(slug: string): { prev: Post | null; next: Post 
     next: currentIndex > 0 ? posts[currentIndex - 1] : null,
   };
 }
+
+export function calculateReadingTime(content: string): number {
+  const wordsPerMinute = 200;
+  const japaneseCharsPerMinute = 500;
+
+  const japaneseChars = (content.match(/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/g) || []).length;
+  const englishWords = content.replace(/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/g, ' ').split(/\s+/).filter(w => w.length > 0).length;
+
+  const minutes = Math.ceil(japaneseChars / japaneseCharsPerMinute + englishWords / wordsPerMinute);
+  return Math.max(1, minutes);
+}


### PR DESCRIPTION
## Summary
- Add Open Graph and Twitter Card metadata to blog posts
- Add BlogPosting JSON-LD structured data for rich search results
- Add reading time calculation (supports Japanese and English)
- Display reading time in blog post header

## Test plan
- [ ] Verify build succeeds
- [ ] Check OG tags in page source
- [ ] Validate JSON-LD with Google Rich Results Test