### PR TITLE
blog: Google Workspace CLI の記事追加

### DIFF
--- a/content/posts/google-workspace-cli.mdx
+++ b/content/posts/google-workspace-cli.mdx
@@ -1,0 +1,222 @@
+---
+title: "Google Workspace CLI 登場 — AI エージェントが Gmail・Drive・Calendar を操作する時代"
+date: "2026-03-05"
+description: "Google 公式の gws コマンドが MCP 対応。Claude Desktop や Gemini CLI から「メール送って」「予定確認して」が一言で可能に。Discovery Service による動的生成で常に最新"
+tags: ["google", "workspace", "cli", "mcp", "ai-agent", "automation"]
+---
+
+## Google が公式 CLI をリリース
+
+Google が [Google Workspace CLI](https://github.com/googleworkspace/cli) を公開した。
+
+**Drive, Gmail, Calendar, Sheets, Docs, Chat, Admin** — これらすべてを単一の `gws` コマンドで操作できる。
+
+そして最大の特徴は **MCP (Model Context Protocol) ネイティブ対応**。Claude Desktop や Gemini CLI から Google Workspace を直接操作できる。
+
+## 3つのゲームチェンジャー要素
+
+### 1. Discovery Service による動的生成
+
+従来の CLI ツールは、Google API が更新されるたびにメンテナンスが必要だった。
+
+`gws` は [Google Discovery Service](https://developers.google.com/discovery) から**自動的に**コマンドを生成する。
+
+| 従来のアプローチ | gws |
+|-----------------|-----|
+| API 更新 → CLI 更新待ち | API 更新 → **即座に反映** |
+| 手動メンテナンス | 自動生成 |
+| 機能追加に遅延 | 常に最新 |
+
+Discovery Service は Google の全 API の「設計図」を提供するサービス。`gws` はこの設計図を読み取り、リアルタイムでコマンドを構築する。
+
+### 2. MCP ネイティブ対応
+
+```bash
+gws mcp --services drive,gmail,calendar
+```
+
+このコマンド一つで、MCP サーバーが起動する。
+
+対応クライアント：
+
+| クライアント | 対応状況 |
+|-------------|---------|
+| **Claude Desktop** | ✅ |
+| **Gemini CLI** | ✅ |
+| **VS Code** | ✅ |
+| **Claude Code** | ✅ |
+
+各サービスは **10〜80個のツール** を追加。クライアントのツール上限（通常50〜100）に注意が必要なため、必要なサービスだけを指定する設計になっている。
+
+### 3. AI Agent Skills 内蔵
+
+[Google Workspace Studio](https://workspace.google.com/studio/) と連携し、自然言語でワークフロー自動化が可能。
+
+> 「毎週金曜、トラッカーの更新をリマインドして」
+
+これだけで Gemini がエージェントを作成する。
+
+## 実際の使い方
+
+### インストール
+
+```bash
+# Go でインストール
+go install github.com/googleworkspace/cli/gws@latest
+
+# または Homebrew
+brew install googleworkspace/tap/gws
+```
+
+### 基本操作
+
+```bash
+# Gmail の未読メールを取得
+gws gmail users.messages.list --userId me --q "is:unread"
+
+# Google Drive のファイル一覧
+gws drive files.list
+
+# カレンダーの予定を取得
+gws calendar events.list --calendarId primary
+```
+
+### MCP サーバーとして起動
+
+```bash
+# Claude Desktop や Gemini CLI から使えるようにする
+gws mcp --services drive,gmail,calendar,sheets
+```
+
+### Claude Desktop での設定例
+
+```json
+{
+  "mcpServers": {
+    "google-workspace": {
+      "command": "gws",
+      "args": ["mcp", "--services", "drive,gmail,calendar"]
+    }
+  }
+}
+```
+
+これで Claude に「今日の予定を教えて」「このファイルを共有して」と言うだけで操作できる。
+
+## 競合ツールとの比較
+
+### GAM / GAM7
+
+[GAM](https://github.com/GAM-team/GAM) は Google Workspace 管理者向けの定番ツール。Jay Lee（現 Google 社員）が開発し、10年以上の実績がある。
+
+| 項目 | gws | GAM/GAM7 |
+|------|-----|----------|
+| **対象** | 全ユーザー | 管理者特化 |
+| **API カバレッジ** | 全サービス（動的） | Admin 中心 |
+| **AI 統合** | ✅ MCP + Agent | ❌ |
+| **メンテナンス** | 自動（Discovery） | 手動 |
+| **成熟度** | 新しい | 実績豊富 |
+
+GAM は管理タスク（ユーザー作成、グループ管理、監査）に強い。`gws` はエンドユーザー向けの全サービス操作と AI 統合に強い。
+
+### サードパーティ MCP サーバー
+
+[google_workspace_mcp](https://github.com/taylorwilsdon/google_workspace_mcp) など、サードパーティの MCP サーバーも存在する。
+
+| 項目 | gws (公式) | サードパーティ |
+|------|-----------|---------------|
+| **サポート** | Google | コミュニティ |
+| **API 更新追従** | 自動 | 手動 |
+| **認証** | 公式 OAuth | 独自実装 |
+
+公式ツールの安心感は大きい。
+
+## 企業での活用事例
+
+[Google Cloud の 2026 AI 予測](https://blog.google/products/google-cloud/ai-business-trends-report-2026/)によると、AI エージェントの企業導入が加速している。
+
+| 企業 | 成果 |
+|------|------|
+| **Telus** | 57,000人が AI 活用、1回の操作で **40分節約** |
+| **Danfoss** | メール注文処理の **80% を自動化**、42時間 → リアルタイム |
+| **Suzano** | SQL クエリ時間 **95% 削減** |
+
+`gws` + AI エージェントの組み合わせは、これらの成果をさらに加速させる可能性がある。
+
+## 開発者への影響
+
+### ワークフロー例
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Claude Code / Gemini CLI                           │
+│       ↓                                             │
+│  gws mcp --services drive,gmail,sheets              │
+│       ↓                                             │
+│  「このスプレッドシートを分析して、                  │
+│    結果をメールで送って」                           │
+│       ↓                                             │
+│  AI が Sheets 読み取り → 分析 → Gmail 送信          │
+└─────────────────────────────────────────────────────┘
+```
+
+### 意味すること
+
+1. **API ラッパーの終焉** — Discovery Service により個別ライブラリが不要に
+2. **ノーコード自動化の民主化** — 開発者でなくても複雑なワークフローを構築
+3. **AI エージェントの実用化** — Workspace 全体を AI が横断操作
+
+## Gemini CLI との統合
+
+[Gemini CLI](https://github.com/google-gemini/gemini-cli) との統合も用意されている。
+
+```bash
+# Gemini CLI に gws 拡張をインストール
+gemini extensions install https://github.com/gemini-cli-extensions/workspace
+```
+
+これで Gemini CLI から直接 Google Workspace を操作できる。
+
+## 注意点
+
+### ツール数の制限
+
+各サービスは 10〜80 個のツールを追加する。MCP クライアントには通常 50〜100 のツール上限がある。
+
+```bash
+# 必要なサービスだけを指定
+gws mcp --services drive,gmail  # ✅ 少数に絞る
+gws mcp --services all          # ⚠️ 上限に注意
+```
+
+### 認証
+
+初回は OAuth 認証が必要。一度認証すれば、トークンはローカルに保存される。
+
+```bash
+# 初回認証
+gws auth login
+```
+
+## まとめ
+
+Google Workspace CLI は **3つの革新** を同時に持ち込んだ：
+
+| 革新 | 影響 |
+|------|------|
+| **動的生成** | メンテナンス不要、常に最新 |
+| **MCP 対応** | あらゆる AI クライアントから操作可能 |
+| **Agent Skills** | 自然言語でワークフロー自動化 |
+
+特に **MCP 対応** は、Claude Code や Gemini CLI から「メール送って」「カレンダー確認して」「ドキュメント作成して」が**ターミナルから一言で**できることを意味する。
+
+Google Workspace を使っている開発者なら、今すぐ試す価値がある。
+
+## 参考リンク
+
+- [Google Workspace CLI - GitHub](https://github.com/googleworkspace/cli)
+- [Google API Discovery Service](https://developers.google.com/discovery)
+- [Google Workspace Studio](https://workspace.google.com/studio/)
+- [GAM - Google Workspace Admin CLI](https://github.com/GAM-team/GAM)
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- [5 ways AI agents will transform work in 2026 - Google Blog](https://blog.google/products/google-cloud/ai-business-trends-report-2026/)

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -11,6 +11,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://hiro8ma.github.io/portfolio/blog/google-workspace-cli</loc>
+    <lastmod>2026-03-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://hiro8ma.github.io/portfolio/blog/claude-code-voice-mode</loc>
     <lastmod>2026-03-03</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Summary
- Google 公式の `gws` コマンドが MCP 対応
- Claude Desktop / Gemini CLI から Google Workspace を直接操作可能
- Discovery Service による動的生成で常に最新 API に追従

## Test plan
- [x] `npm run build` 成功（22ページ生成）
- [x] sitemap.xml 更新済み