### PR TITLE
blog: AnthropicがPentagonのブラックリストに対し訴訟提起

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,12 +3,30 @@
     "allow": [
       "Bash(brew info:*)",
       "Bash(curl:*)",
-      "WebSearch",
+      "Bash(jq:*)",
+      "Bash(cat ~/.claude-code-version)",
+      "Bash(cat ~/.claude-blog-last-check)",
+      "Bash(cat ~/.codex-version)",
+      "Bash(cat ~/.codex-blog-last-check)",
+      "Bash(echo * > ~/.claude-code-version)",
+      "Bash(echo * > ~/.claude-blog-last-check)",
+      "Bash(echo * > ~/.codex-version)",
+      "Bash(echo * > ~/.codex-blog-last-check)",
       "Bash(claude --version)",
-      "Bash(~/.claude-code-version)",
-      "Bash(npm view @anthropic-ai/claude-code version)",
-      "WebFetch(domain:developers.openai.com)",
-      "Bash(~/.codex-version)"
+      "Bash(codex --version)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git branch:*)",
+      "Bash(git status)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr merge:*)",
+      "WebSearch",
+      "WebFetch(domain:claude.com)",
+      "WebFetch(domain:developers.openai.com)"
     ]
   }
 }

--- a/content/posts/anthropic-pentagon-lawsuit.mdx
+++ b/content/posts/anthropic-pentagon-lawsuit.mdx
@@ -1,0 +1,59 @@
+---
+title: "Anthropic、Pentagonのブラックリストに対し訴訟提起 — AI倫理と国家安全保障の衝突"
+date: "2026-03-10"
+description: "Claudeを自律型兵器に使わせないと宣言したAnthropicが連邦政府に訴訟。App Storeでは皮肉にも1位に"
+tags: ["anthropic", "claude", "policy", "ai-ethics", "pentagon"]
+---
+
+## 何が起きたか
+
+Anthropic が2026年3月9日、Trump政権を相手取り2件の連邦訴訟を提起した。
+
+発端はCEO Dario Amodeiの声明。「Claudeを自律型兵器や米国市民の大規模監視には使用させない」と明言したことで、Pentagonが Anthropic を「サプライチェーンリスク」に指定。大統領令により連邦機関全体でのClaude利用が禁止された。
+
+## Anthropicの法的主張
+
+Anthropic は以下の2点を主張する。
+
+| 主張 | 内容 |
+|------|------|
+| 憲法修正第1条違反 | AI安全性に関する会社の立場を理由にした報復 |
+| 法的権限逸脱 | サプライチェーンリスク法の適用範囲を超えている |
+
+訴状の核心は「民間企業が安全ポリシーを持つことへの報復が許されるか」という問い。Pentagon側は「兵器への応用はすべて合法的」と反論し、企業が政府の技術利用を制限できないと主張する。
+
+## 商業利用への影響は限定的
+
+Microsoft、Google、AWS の3社が相次いで声明を発表。防衛部門を除いた商業・エンタープライズ顧客は引き続きClaudeを利用できると確認した。
+
+AWS経由でClaudeを使う日本企業への直接影響はない。
+
+## 逆説的な結果
+
+禁止措置の発表後、Anthropic のアプリは Apple App Store で1位を獲得。Claude の有料サブスクリプションも急増した。
+
+政府からの圧力が、一般ユーザーからの支持に変換された構図だ。
+
+## 日本への影響・考察
+
+日本では防衛省・自衛隊がAI導入を検討する動きが続いている。この訴訟はひとつの問いを突きつける。「AIベンダーが用途制限を課す権利をどこまで認めるか」。
+
+国産AIや海外AIを政府調達する際に、倫理ポリシーが調達条件と衝突するケースは今後増える。この訴訟の判決が判例となれば、日米ともに政府調達のAIガバナンスに影響を与える可能性がある。
+
+エンジニアとして注目すべき点は別にある。Anthropic が軍事利用を拒否しても、会社として存続できた。それは Claude の商業価値が政府依存を超えていることを示す。AI倫理のポリシーは、もはやブランドの一部として機能している。
+
+## まとめ
+
+| 項目 | 概要 |
+|------|------|
+| 出来事 | Anthropic、Pentagon「サプライチェーンリスク」指定に対し訴訟 |
+| 訴訟日 | 2026年3月9日 |
+| 主な主張 | 修正第1条違反・法的権限逸脱 |
+| 商業影響 | AWS/Azure/GCP 経由の非防衛顧客への影響なし |
+| 副作用 | App Store 1位・有料契約急増 |
+
+## 参考リンク
+
+- [Anthropic sues Trump administration over Pentagon blacklist (NPR)](https://www.npr.org/2026/03/09/nx-s1-5742548/anthropic-pentagon-lawsuit-amodai-hegseth)
+- [Microsoft, Google, Amazon say Anthropic Claude remains available (TechCrunch)](https://techcrunch.com/2026/03/06/microsoft-anthropic-claude-remains-available-to-customers-except-the-defense-department/)
+- [Anthropic's Claude is suddenly the most popular iPhone app (CNN)](https://www.cnn.com/2026/03/03/tech/anthropic-claude-ai-app-pentagon)


### PR DESCRIPTION
## Summary

- Anthropic vs Pentagon訴訟（2026年3月9日）の記事を追加
- AI倫理と国家安全保障の衝突、日本への影響を考察
- 既存記事との重複なし